### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Cloud Platform.
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg
    :target: https://pypi.org/project/google-cloud-redis/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.