### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-redis",
     "api_id": "redis.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "redis",
-  "name_pretty": "Cloud Redis",
-  "product_documentation": "https://cloud.google.com/memorystore/docs/redis/",
-  "client_documentation": "https://googleapis.dev/python/redis/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-redis",
-  "distribution_name": "google-cloud-redis",
-  "api_id": "redis.googleapis.com",
-  "requires_billing": true
+    "name": "redis",
+    "name_pretty": "Cloud Redis",
+    "product_documentation": "https://cloud.google.com/memorystore/docs/redis/",
+    "client_documentation": "https://googleapis.dev/python/redis/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-redis",
+    "distribution_name": "google-cloud-redis",
+    "api_id": "redis.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114