### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "redis",
     "name_pretty": "Cloud Redis",
     "product_documentation": "https://cloud.google.com/memorystore/docs/redis/",
-    "client_documentation": "https://googleapis.dev/python/redis/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/redis/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Cloud Platform.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg
    :target: https://pypi.org/project/google-cloud-redis/
 .. _Google Cloud Memorystore for Redis API: https://cloud.google.com/memorystore/
-.. _Client Library Documentation: https://googleapis.dev/python/redis/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/redis/latest
 .. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.